### PR TITLE
Use xhr responseText property and use clearer function name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xhrhelpers",
-  "version": "0.0.2",
+  "version": "0.0.1",
   "description": "xhr testing helper",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Fixes #6.

IE9 xhr objects don't have the `.response` property, so this pull switches to using the xhr `.responseText` property. The function was also renamed for clarity.
