### PR TITLE
Return something more useful if responseText is not valid JSON

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,11 @@ module.exports = {
   },
 
   responseObject: function(response) {
+    try {
+      JSON.parse(response.xhr.responseText);
+    } catch(err) {
+      return {invalid_JSON: response.xhr.responseText};
+    }
     return JSON.parse(response.xhr.responseText);
   },
 


### PR DESCRIPTION
Previously we were returning a syntax error if the responseText was not valid JSON which was causing
errors to be thrown unexpectedly

Related for fixing https://github.com/yola/production/issues/2264